### PR TITLE
Redone the way players are announced

### DIFF
--- a/src/main/java/com/spinalcraft/registrar/Commandler.java
+++ b/src/main/java/com/spinalcraft/registrar/Commandler.java
@@ -1,10 +1,19 @@
 package com.spinalcraft.registrar;
 
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.spinalcraft.spinalpack.Spinalpack;
 
 public class Commandler {
+	@SuppressWarnings("deprecation")
 	public static boolean handle(CommandSender sender, Command cmd, String label, String[] args){
 		if(cmd.getName().equalsIgnoreCase("data")){
 	    	if(args.length == 0)
@@ -18,6 +27,51 @@ public class Commandler {
 	    	info.reportTo(sender);
 	    	return true;
 	    }
+		//used for testing. Resets the announced bit
+		if(cmd.getName().equalsIgnoreCase("announceresetbit")){
+			try{
+				if (args.length == 0){
+					if (sender instanceof Player){
+						setAnnouncementBit(((Player) sender).getUniqueId(), false);
+						return true;
+					} else {
+						return false;
+					}
+				} else {
+					String playerName = args[0];
+					Player player = Bukkit.getPlayer(playerName);
+					if (player == null){
+						sender.sendMessage("Player " + playerName + " not found!");
+					} else {
+						setAnnouncementBit(player.getUniqueId(), false);
+						return true;
+					}
+				}
+			} catch (SQLException e){
+				sender.sendMessage("Database error");
+				e.printStackTrace();
+			}
+		}
+		//This command is called by the site using a socket.
+		if (cmd.getName().equalsIgnoreCase("__announce__")){
+			if (sender instanceof Player){
+				sender.sendMessage("You shouldn't use this command!");
+				return true;
+			}
+			if (args.length == 1){
+				Bukkit.getPluginManager().callEvent(new PlayerSiteRegisterEvent(args[0]));
+				return true;
+			}
+			return true; //At this point its only used by the site, no need to post errors
+		}
 		return false;
+	}
+	
+	private static void setAnnouncementBit(UUID uuid, boolean bit) throws SQLException{
+		String query = "UPDATE " + RegistrarPlugin.dbName + ".applications SET announced = ? WHERE uuid = ?";
+		PreparedStatement stmt = Spinalpack.prepareStatement(query);
+		stmt.setString(1, bit ? "1" : "0");
+		stmt.setString(1, uuid.toString());
+		stmt.execute();
 	}
 }

--- a/src/main/java/com/spinalcraft/registrar/Commandler.java
+++ b/src/main/java/com/spinalcraft/registrar/Commandler.java
@@ -52,6 +52,20 @@ public class Commandler {
 				e.printStackTrace();
 			}
 		}
+		if (cmd.getName().equalsIgnoreCase("removeapprow")){
+			try {
+				if (!(sender instanceof Player)){
+					sender.sendMessage("This can only be used by a player");
+					return true;
+				} else {
+					removeRow(((Player) sender).getUniqueId());
+					return true;
+				}
+			} catch (SQLException e){
+				sender.sendMessage("Database error");
+				e.printStackTrace();
+			}
+		}
 		//This command is called by the site using a socket.
 		if (cmd.getName().equalsIgnoreCase("__announce__")){
 			if (sender instanceof Player){
@@ -71,6 +85,13 @@ public class Commandler {
 		String query = "UPDATE " + RegistrarPlugin.dbName + ".applications SET announced = ? WHERE uuid = ?";
 		PreparedStatement stmt = Spinalpack.prepareStatement(query);
 		stmt.setString(1, bit ? "1" : "0");
+		stmt.setString(2, uuid.toString());
+		stmt.execute();
+	}
+	
+	private static void removeRow(UUID uuid) throws SQLException{
+		String query = "DELETE FROM " + RegistrarPlugin.dbName + ".applications WHERE uuid = ? LIMIT 1";
+		PreparedStatement stmt = Spinalpack.prepareStatement(query);
 		stmt.setString(1, uuid.toString());
 		stmt.execute();
 	}

--- a/src/main/java/com/spinalcraft/registrar/PlayerSiteRegisterEvent.java
+++ b/src/main/java/com/spinalcraft/registrar/PlayerSiteRegisterEvent.java
@@ -1,0 +1,39 @@
+package com.spinalcraft.registrar;
+
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class PlayerSiteRegisterEvent extends Event implements Cancellable{
+	private boolean cancelled = false;
+	private String uuid;
+	private static final HandlerList handlers = new HandlerList();
+	
+	public PlayerSiteRegisterEvent(String uuid) {
+		this.uuid = uuid;
+	}
+	
+	public String getUUID(){
+		return uuid;
+	}
+	
+	@Override
+	public boolean isCancelled() {
+		return cancelled;
+	}
+
+	@Override
+	public void setCancelled(boolean cancel) {
+		this.cancelled = cancel;
+	}
+
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+	
+	public static HandlerList getHandlerList(){
+		return handlers;
+	}
+
+}

--- a/src/main/java/com/spinalcraft/registrar/RegistrarEventListener.java
+++ b/src/main/java/com/spinalcraft/registrar/RegistrarEventListener.java
@@ -1,0 +1,75 @@
+package com.spinalcraft.registrar;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+import com.spinalcraft.spinalpack.Spinalpack;
+
+public class RegistrarEventListener implements Listener{
+	
+	@EventHandler
+	public void onPlayerJoin(PlayerJoinEvent event){
+		Player player = event.getPlayer();
+		try {
+			if (shouldAnnouncePlayer(player)){
+				announcePlayer(player);
+			}
+		} catch (SQLException e) {
+			System.err.println("Database error");
+			e.printStackTrace();
+		}
+	}
+	
+	@EventHandler
+	public void onRegistered(PlayerSiteRegisterEvent event){
+		Player player = Bukkit.getPlayer(UUID.fromString(event.getUUID()));
+		if (player == null){
+			return;
+		} else {
+			try {
+				if (shouldAnnouncePlayer(player)){
+					announcePlayer(player);
+				}
+			} catch (SQLException e) {
+				System.err.println("Database error");
+				e.printStackTrace();
+			}
+		}
+	}
+	
+	private boolean shouldAnnouncePlayer(Player player) throws SQLException{
+		String query = "SELECT announced FROM " + RegistrarPlugin.dbName + ".applications WHERE uuid = ?";
+		PreparedStatement stmt = Spinalpack.prepareStatement(query);
+		stmt.setString(1, player.getUniqueId().toString());
+		ResultSet rs = stmt.executeQuery();
+		if (rs == null){
+			return false;
+		}
+		return rs.getBoolean("announced");
+	}
+	
+	private void announcePlayer(Player player) throws SQLException{
+		if(player == null)
+			return;
+		
+		String query = "UPDATE " + RegistrarPlugin.dbName + ".applications SET announced = 1 WHERE uuid = ?";
+		PreparedStatement stmt = Spinalpack.prepareStatement(query);
+		stmt.setString(1, player.getUniqueId().toString());
+		stmt.execute();
+		
+		Spinalpack spinalPack = (Spinalpack) Bukkit.getPluginManager().getPlugin("Spinalpack");
+		if (spinalPack != null){
+			spinalPack.broadcastMessage(ChatColor.AQUA + "Welcome our newest Spinaling, " + ChatColor.BLUE + player.getName() + ChatColor.AQUA + "!");
+		}
+		player.sendMessage(ChatColor.GOLD + "Welcome to Spinalcraft!");
+	}
+}

--- a/src/main/java/com/spinalcraft/registrar/RegistrarEventListener.java
+++ b/src/main/java/com/spinalcraft/registrar/RegistrarEventListener.java
@@ -51,10 +51,8 @@ public class RegistrarEventListener implements Listener{
 		PreparedStatement stmt = Spinalpack.prepareStatement(query);
 		stmt.setString(1, player.getUniqueId().toString());
 		ResultSet rs = stmt.executeQuery();
-		if (rs == null){
-			return false;
-		}
-		return rs.getBoolean("announced");
+		if (!rs.next()) return false;
+		return !rs.getBoolean("announced");
 	}
 	
 	private void announcePlayer(Player player) throws SQLException{

--- a/src/main/java/com/spinalcraft/registrar/RegistrarPlugin.java
+++ b/src/main/java/com/spinalcraft/registrar/RegistrarPlugin.java
@@ -21,8 +21,11 @@ public class RegistrarPlugin extends JavaPlugin {
 		saveDefaultConfig();
 		loadConfig();
 
-		new Thread(new Announcer()).start();
+		//new Thread(new Announcer()).start();
 		new Thread(new Reminder()).start();
+		
+		RegistrarEventListener listener = new RegistrarEventListener();
+		Bukkit.getPluginManager().registerEvents(listener, this);
 		
 		console.sendMessage(ChatColor.BLUE + "Registrar online!");
 	}
@@ -31,7 +34,6 @@ public class RegistrarPlugin extends JavaPlugin {
 	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args){
 		return Commandler.handle(sender, cmd, label, args);
 	}
-	
 
 	private void loadConfig(){
 		reloadConfig();

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -15,6 +15,11 @@ commands:
     usage: Usage - /announceresetbit <player>
     permission: registrar.announceresetbit
     permission-message: No!
+  removeapprow:
+    description: Removes the row with players application. Testing only
+    usage: Usage - /removeapprow
+    permission: registrar.removeapprow
+    permission-message: No!
   __announce__:
     description: Used by the registration site to announce newly registered players
     usage: Do not use this EVER

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -10,3 +10,13 @@ commands:
     usage: Usage - /data <player>
     permission: registrar.data
     permission-message: No!
+  announceresetbit:
+    description: Reset the announced bit in the db. Testing only
+    usage: Usage - /announceresetbit <player>
+    permission: registrar.announceresetbit
+    permission-message: No!
+  __announce__:
+    description: Used by the registration site to announce newly registered players
+    usage: Do not use this EVER
+    permission: registrar.__announce__
+    permission-message: No!


### PR DESCRIPTION
Added a command for setting the announced bit to zero to test the plugin
Added a command that is used throught a socket to notify the server that
a player has registered.
Added a custom event that fires when a user registers on the site.
Moved the announcing from a thread to an event listener instead
